### PR TITLE
Update license-manager.md

### DIFF
--- a/programming/javascript/api-reference/license/license-manager.md
+++ b/programming/javascript/api-reference/license/license-manager.md
@@ -51,6 +51,7 @@ static initLicense(license: string, immediately?: boolean): void | Promise<void>
 * When `immediately` is undefined or false, this signature of `initLicense` passes the license key to the application for initialization at a later stage. It doesn't provide immediate feedback and is suitable for scenarios where immediate confirmation of license initialization is not required.
 
 * When `immediately` is true, this returns a promise that resolves when the operation finishes. It does not provide any value upon resolution. Please note that it may raise up license related exceptions.
+  Note - The engineResourcePaths should be set before invoking the init function with true as a parameter. 
 
 **Code snippet**
 


### PR DESCRIPTION
  added Note - The engineResourcePaths should be set before invoking the init function with 'true' as the second parameter.