### PR TITLE
SEO: update page titles to remove duplicates

### DIFF
--- a/programming/javascript/api-reference/capture-vision-router/settings.md
+++ b/programming/javascript/api-reference/capture-vision-router/settings.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: CaptureVisionRouter Settings - Dynamsoft Capture Vision JavaScript Edition API
+title: CaptureVisionRouter Settings – Capture Vision JavaScript API
 description: This page introduces APIs related to the Settings of CaptureVisionRouter of Dynamsoft Capture Vision JavaScript Edition.
 keywords: capture vision, router, Settings, api reference, javascript, js
 needAutoGenerateSidebar: true

--- a/programming/javascript/api-reference/core/enum-captured-result-item-type.md
+++ b/programming/javascript/api-reference/core/enum-captured-result-item-type.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: CapturedResultItemType - Dynamsoft Core Enumerations
+title: CapturedResultItemType Enum – Capture Vision  Core Enumerations
 description: The enumeration CapturedResultItemType of Dynamsoft Core describes all types of captured result item.
 keywords: Captured result types
 needGenerateH3Content: true

--- a/programming/javascript/api-reference/core/enum-corner-type.md
+++ b/programming/javascript/api-reference/core/enum-corner-type.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: CornerType - Dynamsoft Core Enumerations
+title: CornerType Enum – Dynamsoft Capture Vision JavaScript API
 description: The enumeration CornerType of Dynamsoft Core describes how the corner is formed by its sides.
 keywords: Corner type
 needGenerateH3Content: true

--- a/programming/javascript/api-reference/core/enum-cross-verification-status.md
+++ b/programming/javascript/api-reference/core/enum-cross-verification-status.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: CrossVerificationStatus - Dynamsoft Core Enumerations
+title: CrossVerificationStatus Enum – Capture Vision JavaScript API
 description: The enumeration CrossVerificationStatus of Dynamsoft Core describes the status of the captured results.
 keywords: cross verification status
 needGenerateH3Content: true

--- a/programming/javascript/api-reference/core/enum-error-code.md
+++ b/programming/javascript/api-reference/core/enum-error-code.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: ErrorCode - Dynamsoft Core Enumerations
+title: ErrorCode Enum – Dynamsoft Capture Vision JavaScript API Ref
 description: The enumeration ErrorCode of Dynamsoft Core describes all error codes.
 keywords: Error code
 needGenerateH3Content: true

--- a/programming/javascript/api-reference/core/enum-image-file-format.md
+++ b/programming/javascript/api-reference/core/enum-image-file-format.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: ImageFileFormat - Dynamsoft Core Enumerations
+title: ImageFileFormat Enum – Dynamsoft Capture Vision JavaScript
 description: The enumeration ImageFileFormat of Dynamsoft Core describes the format of image files.
 keywords: Image pixel format
 needGenerateH3Content: true

--- a/programming/javascript/api-reference/core/enum-image-tag-type.md
+++ b/programming/javascript/api-reference/core/enum-image-tag-type.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: ImageTagType - Dynamsoft Core Enumerations
+title: ImageTagType Enum – Dynamsoft Capture Vision JavaScript SDK
 description: The enumeration ImageTagType of Dynamsoft Core describes the types of image tags.
 keywords: Image tag type
 needGenerateH3Content: true


### PR DESCRIPTION
## Summary
- Update 7 page titles in JavaScript API reference (enums and CaptureVisionRouter) to remove duplicates